### PR TITLE
fix: searchlog log format

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,5 +30,7 @@ services:
       NODE_ENV: development
       GF_LOG_FILTERS: plugin.tencent-cls-grafana-datasource:debug
       GF_LOG_LEVEL: debug
+      #GF_LOG_CONSOLE_FORMAT: json
+      #GF_LOG_FILE_FORMAT: json
       GF_DATAPROXY_LOGGING: 1
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: tencent-cls-grafana-datasource

--- a/pkg/cls/api.go
+++ b/pkg/cls/api.go
@@ -42,6 +42,7 @@ func SearchLog(ctx context.Context, param *clsAPI.SearchLogRequest, region strin
 	request.Query = param.Query
 	request.Context = param.Context
 	request.UseNewAnalysis = param.UseNewAnalysis
+	request.SyntaxRule = param.SyntaxRule
 
 	// 通过 client 对象调用想要访问的接口，需要传入请求对象
 	response, err = client.SearchLog(request)

--- a/pkg/cls/datasource.go
+++ b/pkg/cls/datasource.go
@@ -39,15 +39,16 @@ func QueryLog(ctx context.Context, logServiceParams pluginCommon.LogServiceParam
 		To:             common.Int64Ptr(query.TimeRange.To.UnixNano() / 1e6),
 		Query:          common.StringPtr(logServiceParams.Query),
 		UseNewAnalysis: common.BoolPtr(true),
+		SyntaxRule:     common.Uint64Ptr(logServiceParams.SyntaxRule),
 	}
 	searchLogResponse, searchLogErr := SearchLog(ctx, &requestParam, logServiceParams.Region, opts)
 
 	if searchLogErr != nil {
-		log.DefaultLogger.Error("CLS_SEARCHLOG_ERROR", Stringify(query), Stringify(searchLogErr))
+		log.DefaultLogger.Error("CLS_SEARCHLOG_ERROR", "query", query, "RequestId", Stringify(searchLogErr))
 		dataRes.Error = searchLogErr
 		return dataRes
 	}
-	log.DefaultLogger.Info("CLS_SEARCHLOG_SUCCESS", Stringify(query), searchLogResponse.Response.RequestId) //云 api 不保存入参
+	log.DefaultLogger.Info("CLS_SEARCHLOG_SUCCESS", "query", query, "RequestId", searchLogResponse.Response.RequestId) //云 api 不保存入参
 	searchLogResult := *searchLogResponse.Response
 
 	if *searchLogResult.Analysis {

--- a/pkg/common/model.go
+++ b/pkg/common/model.go
@@ -13,9 +13,10 @@ type QueryModel struct {
 }
 
 type LogServiceParams struct {
-	Region  string `json:"region"`
-	TopicId string `json:"topicId"`
-	Query   string `json:"Query"`
+	Region     string `json:"region"`
+	TopicId    string `json:"topicId"`
+	Query      string `json:"Query"`
+	SyntaxRule uint64 `json:"SyntaxRule"`
 }
 
 type ApiOpts struct {


### PR DESCRIPTION
pass SyntaxRule param to SearchLogRequest

fix #2 log format

text format: 
tencent-cls-grafana-datasource  | logger=plugin.tencent-cls-grafana-datasource t=2025-01-22T03:18:20.266059722Z level=info msg=CLS_SEARCHLOG_SUCCESS RequestId=4dc4cdd2-12a4-4c91-a65e-303eaec4df13 query="map[Interval:1e+09 JSON:map[app:unified-alerting datasource:map[type:tencent-cls-grafana-datasource uid:deapz2gzd51j4d] intervalMs:1000 logServiceParams:map[Query:* | select count(*) as mycount SyntaxRule:1 TopicId:b7bccc80-c67e-4a4a-831b-91c578e0cb25 format:Graph region:ap-chongqing] maxDataPoints:43200 refId:A serviceType:logService] MaxDataPoints:43200 QueryType: RefID:A TimeRange:map[From:2025-01-21T21:18:20Z To:2025-01-22T03:18:20Z]]"

json format: 
tencent-cls-grafana-datasource  | {"RequestId":"dbfaa2f8-adf6-41c7-9741-7ae94015bbdd","level":"info","logger":"plugin.tencent-cls-grafana-datasource","msg":"CLS_SEARCHLOG_SUCCESS","query":{"Interval":1000000000,"JSON":{"app":"unified-alerting","datasource":{"type":"tencent-cls-grafana-datasource","uid":"eeapzubjl2sxsa"},"intervalMs":1000,"logServiceParams":{"Query":"* | select count(*) as count","SyntaxRule":1,"TopicId":"b7bccc80-c67e-4a4a-831b-91c578e0cb25","format":"Graph","region":"ap-chongqing"},"maxDataPoints":43200,"refId":"A","serviceType":"logService"},"MaxDataPoints":43200,"QueryType":"","RefID":"A","TimeRange":{"From":"2025-01-21T21:24:40Z","To":"2025-01-22T03:24:40Z"}},"t":"2025-01-22T03:24:40.304640876Z"}