### PR TITLE
Support CLS topic names and Grafana SQL macros

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.eslint.json'],
     tsconfigRootDir: '.',
     ecmaVersion: 2021,
     sourceType: 'module',
@@ -28,7 +28,7 @@ module.exports = {
     'import/resolver': {
       typescript: {
         alwaysTryTypes: true,
-        project: ['./tsconfig.json'],
+        project: ['./tsconfig.eslint.json'],
       },
     },
   },
@@ -44,10 +44,29 @@ module.exports = {
     process: false,
   },
   plugins: ['@typescript-eslint', 'import', 'prettier', 'react', 'react-hooks'],
+
+  overrides: [
+    {
+      files: ['*.js', 'toolkit/**/*.js'],
+      rules: {
+        '@typescript-eslint/no-require-imports': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        'import/order': 'off',
+        'prettier/prettier': 'off',
+      },
+    },
+    {
+      files: ['src/log-service/common/format/ConvertSearchResultsToDataFrame.ts'],
+      rules: {
+        'prettier/prettier': 'off',
+      },
+    },
+  ],
   rules: {
     'react/display-name': 'warn',
     'react/prop-types': 'off',
     '@typescript-eslint/class-literal-property-style': 'off',
+    '@typescript-eslint/member-ordering': 'off',
     'import/order': [
       'error',
       {
@@ -65,7 +84,7 @@ module.exports = {
       'warn',
       {
         additionalHooks:
-        '^use(Async|AsyncFn|AsyncRetry|Debounce|UpdateEffect|IsomorphicLayoutEffect|DeepCompareEffect|ShallowCompareEffect)$',
+          '^use(Async|AsyncFn|AsyncRetry|Debounce|UpdateEffect|IsomorphicLayoutEffect|DeepCompareEffect|ShallowCompareEffect)$',
       },
     ],
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI Build
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Mage
+        uses: magefile/mage-action@v3
+        with:
+          install-only: true
+
+      - name: Install pnpm
+        run: corepack enable pnpm && corepack prepare pnpm@latest --activate
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build frontend
+        run: pnpm run build
+
+      - name: Build backend (all platforms)
+        run: go mod vendor && mage
+
+      - name: Package plugin
+        run: |
+          cp -r dist tencent-cls-grafana-datasource
+          zip -r tencent-cls-grafana-datasource.zip tencent-cls-grafana-datasource
+          rm -rf tencent-cls-grafana-datasource
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tencent-cls-grafana-datasource-${{ github.sha }}
+          path: tencent-cls-grafana-datasource.zip
+          retention-days: 30
+
+      - name: Update dev pre-release
+        if: github.ref == 'refs/heads/develop'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: dev
+          name: Development Build
+          prerelease: true
+          make_latest: false
+          body: |
+            Auto-updated from develop branch.
+            Commit: ${{ github.sha }}
+          files: tencent-cls-grafana-datasource.zip

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   // Prettier configuration provided by Grafana scaffolding
   ...require('./.config/.prettierrc.js'),
+
+  endOfLine: 'lf',
+  trailingComma: 'all',
 };

--- a/pkg/cls/datasource.go
+++ b/pkg/cls/datasource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	pluginCommon "github.com/tencentcloud/tencent-cls-grafana-datasource/pkg/common"
 	clsAPI "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
@@ -35,15 +36,28 @@ func QueryLog(ctx context.Context, logServiceParams pluginCommon.LogServiceParam
 
 	dataRes := backend.DataResponse{}
 
+	// Use datasource-level default region if query doesn't specify one
+	region := logServiceParams.Region
+	if region == "" {
+		region = opts.Region
+	}
+
+	// Resolve topic name → ID if not already a UUID
+	topicId, err := resolveTopicId(ctx, region, logServiceParams.TopicId, opts)
+	if err != nil {
+		dataRes.Error = err
+		return dataRes
+	}
+
 	requestParam := clsAPI.SearchLogRequest{
-		TopicId:        common.StringPtr(logServiceParams.TopicId),
+		TopicId:        common.StringPtr(topicId),
 		From:           common.Int64Ptr(query.TimeRange.From.UnixNano() / 1e6),
 		To:             common.Int64Ptr(query.TimeRange.To.UnixNano() / 1e6),
 		Query:          common.StringPtr(logServiceParams.Query),
 		UseNewAnalysis: common.BoolPtr(true),
 		SyntaxRule:     common.Uint64Ptr(logServiceParams.SyntaxRule),
 	}
-	searchLogResponse, searchLogErr := SearchLog(ctx, &requestParam, logServiceParams.Region, opts)
+	searchLogResponse, searchLogErr := SearchLog(ctx, &requestParam, region, opts)
 
 	if searchLogErr != nil {
 		log.DefaultLogger.Error("CLS_SEARCHLOG_ERROR", "query", query, "RequestId", Stringify(searchLogErr))
@@ -68,6 +82,14 @@ func QueryLog(ctx context.Context, logServiceParams pluginCommon.LogServiceParam
 			loc = time.UTC
 		}
 		dataRes.Frames = TransferAnalysisRecordsToFrame(logItems, colNames, "", "", loc)
+		// Convert TypeTimeSeriesLong → TypeTimeSeriesWide for Grafana alerting SSE compatibility.
+		// Graph format (histogram + metric + value) produces Long format which SSE rejects.
+		// Table Panel (no time col) fails conversion silently and stays as TypeTable.
+		for i, frame := range dataRes.Frames {
+			if wideFrame, err := data.LongToWide(frame, nil); err == nil {
+				dataRes.Frames[i] = wideFrame
+			}
+		}
 	}
 
 	//log.DefaultLogger.Info("Query call ended", "result", Stringify(dataRes))

--- a/pkg/cls/topic_resolver.go
+++ b/pkg/cls/topic_resolver.go
@@ -1,0 +1,106 @@
+package cls
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	pluginCommon "github.com/tencentcloud/tencent-cls-grafana-datasource/pkg/common"
+	clsAPI "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+)
+
+var topicIdRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func isTopicId(s string) bool {
+	return topicIdRegex.MatchString(s)
+}
+
+type topicCacheEntry struct {
+	topicId   string
+	expiresAt time.Time
+}
+
+// topicCache stores resolved topic name → ID mappings.
+// Key: "region:topicName:secretId"
+var topicCache sync.Map
+
+const topicCacheTTL = 5 * time.Minute
+
+// resolveTopicId returns the TopicId for the given topicNameOrId.
+// If it's already a UUID, returns it as-is.
+// Otherwise queries the CLS DescribeTopics API (with exact match, falling back to fuzzy)
+// and caches the result for topicCacheTTL.
+func resolveTopicId(ctx context.Context, region, topicNameOrId string, opts pluginCommon.ApiOpts) (string, error) {
+	if isTopicId(topicNameOrId) {
+		return topicNameOrId, nil
+	}
+
+	cacheKey := region + ":" + topicNameOrId + ":" + opts.SecretId
+	if entry, ok := topicCache.Load(cacheKey); ok {
+		e := entry.(topicCacheEntry)
+		if time.Now().Before(e.expiresAt) {
+			return e.topicId, nil
+		}
+		topicCache.Delete(cacheKey)
+	}
+
+	credential := common.NewTokenCredential(opts.SecretId, opts.SecretKey, opts.Token)
+	client, err := clsAPI.NewClient(credential, region, cpf)
+	if err != nil {
+		return "", fmt.Errorf("resolve topic %q: create client: %w", topicNameOrId, err)
+	}
+	if opts.Intranet {
+		client, _ = clsAPI.NewClient(credential, region, intranetCpf)
+	}
+
+	topicId, err := describeTopicByName(client, topicNameOrId, true)
+	if err != nil || topicId == "" {
+		// fallback to fuzzy match
+		topicId, err = describeTopicByName(client, topicNameOrId, false)
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolve topic %q: %w", topicNameOrId, err)
+	}
+	if topicId == "" {
+		return "", fmt.Errorf("topic not found: %q", topicNameOrId)
+	}
+
+	log.DefaultLogger.Info("TOPIC_RESOLVED", "name", topicNameOrId, "id", topicId, "region", region)
+	topicCache.Store(cacheKey, topicCacheEntry{topicId: topicId, expiresAt: time.Now().Add(topicCacheTTL)})
+	return topicId, nil
+}
+
+func describeTopicByName(client *clsAPI.Client, name string, exact bool) (string, error) {
+	req := clsAPI.NewDescribeTopicsRequest()
+	req.Filters = []*clsAPI.Filter{{
+		Key:    common.StringPtr("topicName"),
+		Values: []*string{common.StringPtr(name)},
+	}}
+	if exact {
+		req.PreciseSearch = common.Uint64Ptr(1)
+	}
+	limit := int64(10)
+	req.Limit = &limit
+
+	resp, err := client.DescribeTopics(req)
+	if err != nil {
+		return "", err
+	}
+	if resp.Response == nil || len(resp.Response.Topics) == 0 {
+		return "", nil
+	}
+	// prefer exact name match
+	for _, t := range resp.Response.Topics {
+		if t.TopicName != nil && *t.TopicName == name && t.TopicId != nil {
+			return *t.TopicId, nil
+		}
+	}
+	if resp.Response.Topics[0].TopicId != nil {
+		return *resp.Response.Topics[0].TopicId, nil
+	}
+	return "", nil
+}

--- a/pkg/common/model.go
+++ b/pkg/common/model.go
@@ -25,4 +25,5 @@ type ApiOpts struct {
 	SecretKey string `json:"secretKey"`
 	Token     string
 	Intranet  bool
+	Region    string // default region from datasource settings
 }

--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -102,6 +102,10 @@ func getInsSetting(instanceSettings backend.DataSourceInstanceSettings) (opts co
 		}
 	}
 
+	if region, ok := jsonData["region"].(string); ok && region != "" {
+		opts.Region = region
+	}
+
 	if credentialType, ok := jsonData["credentialType"].(string); ok {
 		switch credentialType {
 		case "assumeRole":

--- a/src/log-service/LogServiceDataSource.ts
+++ b/src/log-service/LogServiceDataSource.ts
@@ -50,7 +50,7 @@ const TOPIC_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 async function resolveTopicId(
   topicNameOrId: string,
   region: string,
-  opts: { instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>; ds: DataSourceWithBackend<any, any> }
+  opts: { instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>; ds: DataSourceWithBackend<any, any> },
 ): Promise<string> {
   if (!topicNameOrId || isTopicId(topicNameOrId)) {
     return topicNameOrId;
@@ -65,7 +65,7 @@ async function resolveTopicId(
     const result = await DescribeTopics(
       { Filters: [{ Key: 'topicName', Values: [topicNameOrId] }], PreciseSearch: preciseSearch, Limit: 10 },
       region,
-      opts
+      opts,
     );
     const topics = (result as any)?.Topics ?? [];
     const match = topics.find((t: any) => t.TopicName === topicNameOrId) ?? topics[0];
@@ -97,7 +97,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     const [from, to] = [range.from, range.to].map((item) => item.valueOf()) as number[];
     const requestTargets = targets.map((target) => {
       const region = this.getRegion(
-        target.logServiceParams?.region ? getTemplateSrv().replace(target.logServiceParams.region) : ''
+        target.logServiceParams?.region ? getTemplateSrv().replace(target.logServiceParams.region) : '',
       );
       const TopicId = target.logServiceParams?.TopicId ? getTemplateSrv().replace(target.logServiceParams.TopicId) : '';
       const Query = addQueryResultLimit(
@@ -105,9 +105,9 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
           replaceClsQueryWithTemplateSrv(target.logServiceParams?.Query || '', scopedVars),
           from,
           to,
-          maxDataPoints
+          maxDataPoints,
         ),
-        target.logServiceParams
+        target.logServiceParams,
       );
 
       return {
@@ -124,7 +124,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     // 过滤后的有效 target 列表,需单独保存:framesArray 的下标与 activeTargets 一一对应,
     // 不能用 requestTargets 的原始下标(隐藏的 target 被过滤后会导致下标错位)。
     const activeTargets = requestTargets.filter(
-      (target) => !target.hide && target.logServiceParams?.region && target.logServiceParams?.TopicId
+      (target) => !target.hide && target.logServiceParams?.region && target.logServiceParams?.TopicId,
     );
     const dataFramePromise: Promise<DataFrame[]>[] = activeTargets.map((target) =>
       resolveTopicId(target.logServiceParams?.TopicId as string, target.logServiceParams?.region as string, {
@@ -144,9 +144,9 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
             Limit: target.logServiceParams?.MaxResultNum,
           },
           target.logServiceParams?.region as string,
-          { instanceSettings: this.instanceSettings, ds: this.parentDs }
-        ).then((result) => ConvertSearchResultsToDataFrame(formatSearchLog(result), target, this.instanceSettings))
-      )
+          { instanceSettings: this.instanceSettings, ds: this.parentDs },
+        ).then((result) => ConvertSearchResultsToDataFrame(formatSearchLog(result), target, this.instanceSettings)),
+      ),
     );
 
     const output$ = new Observable<DataQueryResponse>((subscriber) => {
@@ -219,9 +219,9 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
       replaceClsIntervalMacro(
         replaceClsQueryWithTemplateSrv(logServiceParams?.Query as string),
         options.range!.from.valueOf(),
-        options.range!.to.valueOf()
+        options.range!.to.valueOf(),
       ),
-      logServiceParams
+      logServiceParams,
     );
 
     if (!options.range) {
@@ -246,8 +246,8 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
           {
             instanceSettings: this.instanceSettings,
             ds: this.parentDs,
-          }
-        )
+          },
+        ),
       );
       if (analysisColumns.length > 0 && analysisRecords.length > 0) {
         const firstColumn = analysisColumns[0];
@@ -275,7 +275,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
         {
           instanceSettings: this.instanceSettings,
           ds: this.parentDs,
-        }
+        },
       );
       return {
         status: 'success',
@@ -336,7 +336,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
           NextLogs: direction !== 'BACKWARD' ? limit : 0,
         },
         metaField?.labels.region,
-        { instanceSettings: this.instanceSettings, ds: this.parentDs }
+        { instanceSettings: this.instanceSettings, ds: this.parentDs },
       );
       const frame = ConvertLogContextToDataFrame(logContext);
       return {

--- a/src/log-service/LogServiceDataSource.ts
+++ b/src/log-service/LogServiceDataSource.ts
@@ -22,10 +22,61 @@ import {
   formatSearchLog,
   LogFieldReservedName,
 } from './common/format';
-import { DescribeLogContext, LogInfo, SearchLog } from '../common/model';
+import { DescribeLogContext, DescribeTopics, LogInfo, SearchLog } from '../common/model';
 import { MyDataSourceOptions, QueryInfo } from '../types';
 import { toTimeSeriesMany } from './common/format/prepareTimeSeries';
-import { addQueryResultLimit, getRawQuery, replaceClsQueryWithTemplateSrv } from './common/utils/query';
+import {
+  addQueryResultLimit,
+  getRawQuery,
+  replaceClsIntervalMacro,
+  replaceClsQueryWithTemplateSrv,
+} from './common/utils/query';
+
+// UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+const topicIdRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isTopicId(s: string): boolean {
+  return topicIdRegex.test(s);
+}
+
+interface TopicCacheEntry {
+  topicId: string;
+  expiresAt: number;
+}
+
+const topicCache = new Map<string, TopicCacheEntry>();
+const TOPIC_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+async function resolveTopicId(
+  topicNameOrId: string,
+  region: string,
+  opts: { instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>; ds: DataSourceWithBackend<any, any> }
+): Promise<string> {
+  if (!topicNameOrId || isTopicId(topicNameOrId)) {
+    return topicNameOrId;
+  }
+  const cacheKey = `${region}:${topicNameOrId}`;
+  const cached = topicCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.topicId;
+  }
+  // exact match first, fallback to fuzzy
+  for (const preciseSearch of [1, 0]) {
+    const result = await DescribeTopics(
+      { Filters: [{ Key: 'topicName', Values: [topicNameOrId] }], PreciseSearch: preciseSearch, Limit: 10 },
+      region,
+      opts
+    );
+    const topics = (result as any)?.Topics ?? [];
+    const match = topics.find((t: any) => t.TopicName === topicNameOrId) ?? topics[0];
+    if (match?.TopicId) {
+      topicCache.set(cacheKey, { topicId: match.TopicId, expiresAt: Date.now() + TOPIC_CACHE_TTL_MS });
+      return match.TopicId;
+    }
+  }
+  console.warn(`[CLS] topic not found: "${topicNameOrId}" in region "${region}"`);
+  return topicNameOrId; // return as-is, let the API surface the error
+}
 
 export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceOptions> {
   public readonly instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>;
@@ -36,15 +87,27 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     this.instanceSettings = instanceSettings;
   }
 
+  /** Resolve effective region: query region → datasource default region */
+  private getRegion(queryRegion?: string): string {
+    return queryRegion || this.instanceSettings.jsonData.region || '';
+  }
+
   query(request: DataQueryRequest<QueryInfo>) {
-    const { range, targets, scopedVars } = request;
+    const { range, targets, scopedVars, maxDataPoints } = request;
     const [from, to] = [range.from, range.to].map((item) => item.valueOf()) as number[];
     const requestTargets = targets.map((target) => {
-      const region = target.logServiceParams?.region ? getTemplateSrv().replace(target.logServiceParams.region) : '';
+      const region = this.getRegion(
+        target.logServiceParams?.region ? getTemplateSrv().replace(target.logServiceParams.region) : ''
+      );
       const TopicId = target.logServiceParams?.TopicId ? getTemplateSrv().replace(target.logServiceParams.TopicId) : '';
       const Query = addQueryResultLimit(
-        replaceClsQueryWithTemplateSrv(target.logServiceParams?.Query || '', scopedVars),
-        target.logServiceParams,
+        replaceClsIntervalMacro(
+          replaceClsQueryWithTemplateSrv(target.logServiceParams?.Query || '', scopedVars),
+          from,
+          to,
+          maxDataPoints
+        ),
+        target.logServiceParams
       );
 
       return {
@@ -61,24 +124,29 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     // 过滤后的有效 target 列表,需单独保存:framesArray 的下标与 activeTargets 一一对应,
     // 不能用 requestTargets 的原始下标(隐藏的 target 被过滤后会导致下标错位)。
     const activeTargets = requestTargets.filter(
-      (target) => !target.hide && target.logServiceParams?.region && target.logServiceParams?.TopicId,
+      (target) => !target.hide && target.logServiceParams?.region && target.logServiceParams?.TopicId
     );
     const dataFramePromise: Promise<DataFrame[]>[] = activeTargets.map((target) =>
-      SearchLog(
-        {
-          TopicId: target.logServiceParams?.TopicId as string,
-          Query:
-            target.logServiceParams?.format === 'Log'
-              ? getRawQuery(target.logServiceParams?.Query)
-              : (target.logServiceParams?.Query as string),
-          From: from,
-          To: to,
-          SyntaxRule: target.logServiceParams?.SyntaxRule,
-          Limit: target.logServiceParams?.MaxResultNum,
-        },
-        target.logServiceParams?.region as string,
-        { instanceSettings: this.instanceSettings, ds: this.parentDs },
-      ).then((result) => ConvertSearchResultsToDataFrame(formatSearchLog(result), target, this.instanceSettings)),
+      resolveTopicId(target.logServiceParams?.TopicId as string, target.logServiceParams?.region as string, {
+        instanceSettings: this.instanceSettings,
+        ds: this.parentDs,
+      }).then((topicId) =>
+        SearchLog(
+          {
+            TopicId: topicId,
+            Query:
+              target.logServiceParams?.format === 'Log'
+                ? getRawQuery(target.logServiceParams?.Query)
+                : (target.logServiceParams?.Query as string),
+            From: from,
+            To: to,
+            SyntaxRule: target.logServiceParams?.SyntaxRule,
+            Limit: target.logServiceParams?.MaxResultNum,
+          },
+          target.logServiceParams?.region as string,
+          { instanceSettings: this.instanceSettings, ds: this.parentDs }
+        ).then((result) => ConvertSearchResultsToDataFrame(formatSearchLog(result), target, this.instanceSettings))
+      )
     );
 
     const output$ = new Observable<DataQueryResponse>((subscriber) => {
@@ -145,17 +213,25 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
 
   async metricFindQuery(query: QueryInfo['logServiceParams'], options: any): Promise<MetricFindValue[]> {
     const logServiceParams = query;
-    const region = logServiceParams?.region ? getTemplateSrv().replace(logServiceParams.region) : '';
-    const TopicId = logServiceParams?.TopicId ? getTemplateSrv().replace(logServiceParams.TopicId) : '';
+    const region = this.getRegion(logServiceParams?.region ? getTemplateSrv().replace(logServiceParams.region) : '');
+    const rawTopicId = logServiceParams?.TopicId ? getTemplateSrv().replace(logServiceParams.TopicId) : '';
     const Query = addQueryResultLimit(
-      replaceClsQueryWithTemplateSrv(logServiceParams?.Query as string),
-      logServiceParams,
+      replaceClsIntervalMacro(
+        replaceClsQueryWithTemplateSrv(logServiceParams?.Query as string),
+        options.range!.from.valueOf(),
+        options.range!.to.valueOf()
+      ),
+      logServiceParams
     );
 
     if (!options.range) {
       return [];
     }
-    if (region && TopicId && Query) {
+    if (rawTopicId && Query) {
+      const TopicId = await resolveTopicId(rawTopicId, region, {
+        instanceSettings: this.instanceSettings,
+        ds: this.parentDs,
+      });
       const { analysisColumns, analysisRecords } = formatSearchLog(
         await SearchLog(
           {
@@ -170,8 +246,8 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
           {
             instanceSettings: this.instanceSettings,
             ds: this.parentDs,
-          },
-        ),
+          }
+        )
       );
       if (analysisColumns.length > 0 && analysisRecords.length > 0) {
         const firstColumn = analysisColumns[0];
@@ -186,7 +262,6 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
 
   async testDatasource() {
     try {
-      // 使用SearchLog接口直接查询日志，根据是否遇到鉴权错误，判断秘钥合法性
       await SearchLog(
         {
           TopicId: '',
@@ -196,11 +271,11 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
           SyntaxRule: 1,
           Limit: 100,
         },
-        'ap-shanghai',
+        this.getRegion() || 'ap-shanghai',
         {
           instanceSettings: this.instanceSettings,
           ds: this.parentDs,
-        },
+        }
       );
       return {
         status: 'success',
@@ -221,16 +296,11 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     }
   }
 
-  /** histogram support
-   * @link https://github.com/grafana/grafana/blob/942be4215afaea27757fb3a034126452aaf3fab2/public/app/plugins/datasource/loki/datasource.ts#L115-L115
-   */
-  getLogsVolumeDataProvider(/* request: DataQueryRequest<QueryInfo> */): Observable<DataQueryResponse> | undefined {
+  getLogsVolumeDataProvider(): Observable<DataQueryResponse> | undefined {
     return undefined;
   }
 
-  /** context disabled */
   showContextToggle = (row: LogRowModel) => {
-    /** ConvertLogJsonToDataFrameDTO 函数中，将上下文相关值处理为 LogFieldReservedName.META field */
     const metaField = row.dataFrame.fields.find((item) => item.name === LogFieldReservedName.META);
     try {
       if (metaField?.labels?.region && metaField?.labels.TopicId) {
@@ -266,7 +336,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
           NextLogs: direction !== 'BACKWARD' ? limit : 0,
         },
         metaField?.labels.region,
-        { instanceSettings: this.instanceSettings, ds: this.parentDs },
+        { instanceSettings: this.instanceSettings, ds: this.parentDs }
       );
       const frame = ConvertLogContextToDataFrame(logContext);
       return {

--- a/src/log-service/LogServiceDataSource.ts
+++ b/src/log-service/LogServiceDataSource.ts
@@ -28,8 +28,8 @@ import { toTimeSeriesMany } from './common/format/prepareTimeSeries';
 import {
   addQueryResultLimit,
   getRawQuery,
-  replaceClsIntervalMacro,
   replaceClsQueryWithTemplateSrv,
+  replaceClsSqlMacros,
 } from './common/utils/query';
 
 // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -101,7 +101,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
       );
       const TopicId = target.logServiceParams?.TopicId ? getTemplateSrv().replace(target.logServiceParams.TopicId) : '';
       const Query = addQueryResultLimit(
-        replaceClsIntervalMacro(
+        replaceClsSqlMacros(
           replaceClsQueryWithTemplateSrv(target.logServiceParams?.Query || '', scopedVars),
           from,
           to,
@@ -216,7 +216,7 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     const region = this.getRegion(logServiceParams?.region ? getTemplateSrv().replace(logServiceParams.region) : '');
     const rawTopicId = logServiceParams?.TopicId ? getTemplateSrv().replace(logServiceParams.TopicId) : '';
     const Query = addQueryResultLimit(
-      replaceClsIntervalMacro(
+      replaceClsSqlMacros(
         replaceClsQueryWithTemplateSrv(logServiceParams?.Query as string),
         options.range!.from.valueOf(),
         options.range!.to.valueOf(),

--- a/src/log-service/common/utils/query.test.ts
+++ b/src/log-service/common/utils/query.test.ts
@@ -1,4 +1,4 @@
-import { calcClsInterval, replaceClsIntervalMacro } from './query';
+import { calcClsInterval, CLS_SQL_MACRO_NAMES, replaceClsIntervalMacro, replaceClsSqlMacros } from './query';
 
 const h = (n: number) => n * 3_600_000;
 const d = (n: number) => n * 86_400_000;
@@ -40,52 +40,151 @@ describe('calcClsInterval', () => {
   });
 });
 
-describe('replaceClsIntervalMacro', () => {
+describe('CLS SQL macro metadata', () => {
+  it('includes Grafana SQL macro names plus CLS interval aliases', () => {
+    expect(CLS_SQL_MACRO_NAMES).toEqual([
+      '$__time',
+      '$__timeEpoch',
+      '$__timeFilter',
+      '$__timeFrom',
+      '$__timeTo',
+      '$__timeGroup',
+      '$__timeGroupAlias',
+      '$__unixEpochFilter',
+      '$__unixEpochNanoFilter',
+      '$__unixEpochNanoFrom',
+      '$__unixEpochNanoTo',
+      '$__unixEpochGroup',
+      '$__unixEpochGroupAlias',
+      '$__interval',
+      '$__interval_ms',
+      '$__cls_interval',
+      '$__cls_interval_ms',
+    ]);
+  });
+});
+
+describe('replaceClsSqlMacros interval aliases', () => {
   it('replaces $__cls_interval in SQL query', () => {
     const query =
       '* | SELECT histogram(cast(__TIMESTAMP__ as timestamp), interval $__cls_interval) as time, count(*) as cnt';
-    const result = replaceClsIntervalMacro(query, 0, h(6));
+    const result = replaceClsSqlMacros(query, 0, h(6));
     expect(result).toBe(
       '* | SELECT histogram(cast(__TIMESTAMP__ as timestamp), interval 144 second) as time, count(*) as cnt',
     );
   });
 
+  it('replaces $__interval as Grafana SQL compatible alias', () => {
+    const query = '* | SELECT histogram(cast(__TIMESTAMP__ as timestamp), interval $__interval) as time';
+    expect(replaceClsSqlMacros(query, 0, h(24))).toBe(
+      '* | SELECT histogram(cast(__TIMESTAMP__ as timestamp), interval 576 second) as time',
+    );
+  });
+
   it('replaces multiple occurrences', () => {
-    const query = 'SELECT $__cls_interval, $__cls_interval FROM t';
-    const result = replaceClsIntervalMacro(query, 0, h(24));
+    const query = 'SELECT $__cls_interval, $__interval FROM t';
+    const result = replaceClsSqlMacros(query, 0, h(24));
     expect(result).toBe('SELECT 576 second, 576 second FROM t');
   });
 
   it('returns query unchanged when macro is absent', () => {
     const query = '* | SELECT count(*) FROM t';
-    expect(replaceClsIntervalMacro(query, 0, h(6))).toBe(query);
+    expect(replaceClsSqlMacros(query, 0, h(6))).toBe(query);
   });
 
   it('handles empty string', () => {
-    expect(replaceClsIntervalMacro('', 0, h(1))).toBe('');
+    expect(replaceClsSqlMacros('', 0, h(1))).toBe('');
   });
 
-  it('replaces $__cls_interval_ms with exact bucket milliseconds (6h → 144000)', () => {
-    const query = 'count(*) / ($__cls_interval_ms / 60000.0) as rpm';
-    expect(replaceClsIntervalMacro(query, 0, h(6))).toBe('count(*) / (144000 / 60000.0) as rpm');
-  });
-
-  it('replaces both $__cls_interval_ms and $__cls_interval in same query', () => {
-    const query = 'histogram(ts, interval $__cls_interval), count(*) / ($__cls_interval_ms / 60000.0) as rpm';
-    // 6h → 144 second = 144000ms
-    expect(replaceClsIntervalMacro(query, 0, h(6))).toBe(
-      'histogram(ts, interval 144 second), count(*) / (144000 / 60000.0) as rpm',
-    );
-  });
-
-  it('$__cls_interval_ms and $__cls_interval are exactly consistent', () => {
-    // 12h → ceil(43200000/150/1000) = 288 second = 288000ms
-    const query = '$__cls_interval_ms $__cls_interval';
-    expect(replaceClsIntervalMacro(query, 0, h(12))).toBe('288000 288 second');
+  it('replaces $__cls_interval_ms and $__interval_ms with exact bucket milliseconds', () => {
+    const query = 'count(*) / ($__cls_interval_ms / 60000.0) as rpm, $__interval_ms as bucket_ms';
+    expect(replaceClsSqlMacros(query, 0, h(6))).toBe('count(*) / (144000 / 60000.0) as rpm, 144000 as bucket_ms');
   });
 
   it('$__cls_interval_ms is not corrupted by $__cls_interval replacement', () => {
-    const query = '$__cls_interval_ms';
-    expect(replaceClsIntervalMacro(query, 0, h(1))).toBe('24000');
+    const query = '$__cls_interval_ms $__cls_interval $__interval_ms $__interval';
+    expect(replaceClsSqlMacros(query, 0, h(1))).toBe('24000 24 second 24000 24 second');
+  });
+
+  it('keeps deprecated replaceClsIntervalMacro compatible', () => {
+    expect(replaceClsIntervalMacro('$__cls_interval_ms $__cls_interval', 0, h(12))).toBe('288000 288 second');
+  });
+});
+
+describe('replaceClsSqlMacros Grafana SQL time macros', () => {
+  const fromMs = 1_700_000_000_000;
+  const toMs = fromMs + h(6);
+
+  it('expands $__timeGroup to CLS histogram expression', () => {
+    const query = '* | select $__timeGroup(__TIMESTAMP__, $__interval), count(*) as cnt group by 1';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 144 second), count(*) as cnt group by 1',
+    );
+  });
+
+  it('expands $__timeGroupAlias with time alias', () => {
+    const query = '* | select $__timeGroupAlias(__TIMESTAMP__, 5 minute), count(*) group by time';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 5 minute) as time, count(*) group by time',
+    );
+  });
+
+  it('uses $__interval when $__timeGroup interval argument is omitted', () => {
+    const query = '* | select $__timeGroupAlias(__TIMESTAMP__), count(*) group by time';
+    expect(replaceClsSqlMacros(query, fromMs, toMs, 1000)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 22 second) as time, count(*) group by time',
+    );
+  });
+
+  it('expands $__time and avoids double casting existing timestamp expressions', () => {
+    expect(replaceClsSqlMacros('$__time(__TIMESTAMP__)', fromMs, toMs)).toBe(
+      'cast(__TIMESTAMP__ as timestamp) as time',
+    );
+    expect(replaceClsSqlMacros('$__time(cast(ts as timestamp))', fromMs, toMs)).toBe('cast(ts as timestamp) as time');
+  });
+
+  it('expands $__timeEpoch', () => {
+    expect(replaceClsSqlMacros('$__timeEpoch(__TIMESTAMP__)', fromMs, toMs)).toBe(
+      'to_unixtime(cast(__TIMESTAMP__ as timestamp)) as time',
+    );
+  });
+
+  it('expands $__timeFilter and zero-arg time bounds', () => {
+    const query = '* | select count(*) where $__timeFilter(__TIMESTAMP__) and ts >= $__timeFrom() and ts <= $__timeTo';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      `* | select count(*) where __TIMESTAMP__ >= ${fromMs} AND __TIMESTAMP__ <= ${toMs} and ts >= ${fromMs} and ts <= ${toMs}`,
+    );
+  });
+
+  it('parses nested comma expressions inside macro arguments', () => {
+    const query = "* | select $__timeGroupAlias(date_parse(ts, '%Y-%m-%d,%H:%i:%s'), $__interval), count(*)";
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      "* | select histogram(date_parse(ts, '%Y-%m-%d,%H:%i:%s'), interval 144 second) as time, count(*)",
+    );
+  });
+});
+
+describe('replaceClsSqlMacros Grafana SQL unix epoch macros', () => {
+  const fromMs = 1_700_000_000_000;
+  const toMs = fromMs + h(6);
+
+  it('expands $__unixEpochFilter', () => {
+    expect(replaceClsSqlMacros('$__unixEpochFilter(epoch_s)', fromMs, toMs)).toBe(
+      'epoch_s >= 1700000000 AND epoch_s <= 1700021600',
+    );
+  });
+
+  it('expands $__unixEpochNanoFilter and nano bounds', () => {
+    const query = '$__unixEpochNanoFilter(epoch_ns) $__unixEpochNanoFrom() $__unixEpochNanoTo';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      'epoch_ns >= 1700000000000000000 AND epoch_ns <= 1700021600000000000 1700000000000000000 1700021600000000000',
+    );
+  });
+
+  it('expands unix epoch group macros using from_unixtime', () => {
+    const query = '$__unixEpochGroupAlias(epoch_s, $__interval), $__unixEpochGroup(epoch_s, 5 minute)';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      'histogram(from_unixtime(epoch_s), interval 144 second) as time, histogram(from_unixtime(epoch_s), interval 5 minute)',
+    );
   });
 });

--- a/src/log-service/common/utils/query.test.ts
+++ b/src/log-service/common/utils/query.test.ts
@@ -1,0 +1,91 @@
+import { calcClsInterval, replaceClsIntervalMacro } from './query';
+
+const h = (n: number) => n * 3_600_000;
+const d = (n: number) => n * 86_400_000;
+
+describe('calcClsInterval', () => {
+  // rawSeconds = ceil(rangeMs / 150 / 1000)
+  it('1h range → 24 second  (3600000/150/1000 = 24)', () => {
+    expect(calcClsInterval(0, h(1))).toBe('24 second');
+  });
+
+  it('6h range → 144 second  (21600000/150/1000 = 144)', () => {
+    expect(calcClsInterval(0, h(6))).toBe('144 second');
+  });
+
+  it('24h range → 576 second  (86400000/150/1000 = 576)', () => {
+    expect(calcClsInterval(0, h(24))).toBe('576 second');
+  });
+
+  it('7d range → 4032 second  (604800000/150/1000 = 4032)', () => {
+    expect(calcClsInterval(0, d(7))).toBe('4032 second');
+  });
+
+  it('30d range → 17280 second', () => {
+    expect(calcClsInterval(0, d(30))).toBe('17280 second');
+  });
+
+  it('very short range → 1 second (minimum)', () => {
+    expect(calcClsInterval(0, 1000)).toBe('1 second');
+  });
+
+  it('respects custom maxDataPoints', () => {
+    // 6h / 1000 = 21.6s → ceil = 22 second
+    expect(calcClsInterval(0, h(6), 1000)).toBe('22 second');
+  });
+
+  it('works with non-zero from', () => {
+    const base = 1_700_000_000_000;
+    expect(calcClsInterval(base, base + h(6))).toBe('144 second');
+  });
+});
+
+describe('replaceClsIntervalMacro', () => {
+  it('replaces $__cls_interval in SQL query', () => {
+    const query =
+      '* | SELECT histogram(cast(__TIMESTAMP__ as timestamp), interval $__cls_interval) as time, count(*) as cnt';
+    const result = replaceClsIntervalMacro(query, 0, h(6));
+    expect(result).toBe(
+      '* | SELECT histogram(cast(__TIMESTAMP__ as timestamp), interval 144 second) as time, count(*) as cnt',
+    );
+  });
+
+  it('replaces multiple occurrences', () => {
+    const query = 'SELECT $__cls_interval, $__cls_interval FROM t';
+    const result = replaceClsIntervalMacro(query, 0, h(24));
+    expect(result).toBe('SELECT 576 second, 576 second FROM t');
+  });
+
+  it('returns query unchanged when macro is absent', () => {
+    const query = '* | SELECT count(*) FROM t';
+    expect(replaceClsIntervalMacro(query, 0, h(6))).toBe(query);
+  });
+
+  it('handles empty string', () => {
+    expect(replaceClsIntervalMacro('', 0, h(1))).toBe('');
+  });
+
+  it('replaces $__cls_interval_ms with exact bucket milliseconds (6h → 144000)', () => {
+    const query = 'count(*) / ($__cls_interval_ms / 60000.0) as rpm';
+    expect(replaceClsIntervalMacro(query, 0, h(6))).toBe('count(*) / (144000 / 60000.0) as rpm');
+  });
+
+  it('replaces both $__cls_interval_ms and $__cls_interval in same query', () => {
+    const query = 'histogram(ts, interval $__cls_interval), count(*) / ($__cls_interval_ms / 60000.0) as rpm';
+    // 6h → 144 second = 144000ms
+    expect(replaceClsIntervalMacro(query, 0, h(6))).toBe(
+      'histogram(ts, interval 144 second), count(*) / (144000 / 60000.0) as rpm',
+    );
+  });
+
+  it('$__cls_interval_ms and $__cls_interval are exactly consistent', () => {
+    // 12h → ceil(43200000/150/1000) = 288 second = 288000ms
+    const query = '$__cls_interval_ms $__cls_interval';
+    expect(replaceClsIntervalMacro(query, 0, h(12))).toBe('288000 288 second');
+  });
+
+  it('$__cls_interval_ms is not corrupted by $__cls_interval replacement', () => {
+    const query = '$__cls_interval_ms';
+    expect(replaceClsIntervalMacro(query, 0, h(1))).toBe('24000');
+  });
+});

--- a/src/log-service/common/utils/query.ts
+++ b/src/log-service/common/utils/query.ts
@@ -2,6 +2,36 @@ import { getTemplateSrv } from '@grafana/runtime';
 
 import { QueryInfo } from '../../../types';
 
+const DEFAULT_MAX_DATA_POINTS = 150;
+const MS_PER_SECOND = 1000;
+const NS_PER_MS = 1_000_000;
+
+export const CLS_SQL_MACRO_NAMES = [
+  '$__time',
+  '$__timeEpoch',
+  '$__timeFilter',
+  '$__timeFrom',
+  '$__timeTo',
+  '$__timeGroup',
+  '$__timeGroupAlias',
+  '$__unixEpochFilter',
+  '$__unixEpochNanoFilter',
+  '$__unixEpochNanoFrom',
+  '$__unixEpochNanoTo',
+  '$__unixEpochGroup',
+  '$__unixEpochGroupAlias',
+  '$__interval',
+  '$__interval_ms',
+  '$__cls_interval',
+  '$__cls_interval_ms',
+];
+
+type MacroContext = {
+  fromMs: number;
+  toMs: number;
+  maxDataPoints?: number;
+};
+
 /**
  * Compute the CLS SQL histogram interval string for the given time range.
  *
@@ -17,34 +47,265 @@ import { QueryInfo } from '../../../types';
  * calcClsInterval(0, 21_600_000)    // "144 second" (6 h / 150)
  * calcClsInterval(0, 86_400_000)    // "576 second" (24 h / 150)
  */
-export function calcClsInterval(fromMs: number, toMs: number, maxDataPoints = 150): string {
-  const rawSeconds = Math.max(1, Math.ceil((toMs - fromMs) / maxDataPoints / 1000));
+export function calcClsInterval(fromMs: number, toMs: number, maxDataPoints = DEFAULT_MAX_DATA_POINTS): string {
+  const rawSeconds = getRawIntervalSeconds({ fromMs, toMs, maxDataPoints });
   return `${rawSeconds} second`;
 }
 
 /**
- * Replace all occurrences of `$__cls_interval` in the query string with the
- * computed CLS SQL interval expression (e.g. "24 second"), and
- * `$__cls_interval_ms` with the exact corresponding millisecond value.
+ * Replace CLS SQL macros and Grafana SQL-style macros in the query string.
  *
- * Use `$__cls_interval_ms` in SELECT expressions to normalize counts/sums to
- * per-minute rates — the divisor exactly matches the histogram bucket width:
- *   count(*) / ($__cls_interval_ms / 60000.0) as rpm
- *   sum(cast(input_tokens as double)) / ($__cls_interval_ms / 60000.0) as tpm
+ * Supported aliases:
+ * - `$__interval` / `$__interval_ms`
+ * - `$__cls_interval` / `$__cls_interval_ms`
+ *
+ * Supported SQL macros, aligned with Grafana SQL macro names where possible:
+ * - `$__time`, `$__timeEpoch`, `$__timeFilter`, `$__timeFrom`, `$__timeTo`
+ * - `$__timeGroup`, `$__timeGroupAlias`
+ * - `$__unixEpochFilter`, `$__unixEpochNanoFilter`, `$__unixEpochNanoFrom`, `$__unixEpochNanoTo`
+ * - `$__unixEpochGroup`, `$__unixEpochGroupAlias`
  */
+export function replaceClsSqlMacros(queryString: string, fromMs: number, toMs: number, maxDataPoints?: number): string {
+  if (!queryString.includes('$__')) {
+    return queryString;
+  }
+
+  const context: MacroContext = { fromMs, toMs, maxDataPoints };
+  let result = queryString;
+
+  result = replaceMacroFunction(result, '$__timeGroupAlias', (args) => {
+    const [column, interval] = args;
+    return `${toTimeGroupExpression(column, interval, context)} as time`;
+  });
+  result = replaceMacroFunction(result, '$__timeGroup', (args) => {
+    const [column, interval] = args;
+    return toTimeGroupExpression(column, interval, context);
+  });
+  result = replaceMacroFunction(result, '$__unixEpochGroupAlias', (args) => {
+    const [column, interval] = args;
+    return `${toUnixEpochGroupExpression(column, interval, context)} as time`;
+  });
+  result = replaceMacroFunction(result, '$__unixEpochGroup', (args) => {
+    const [column, interval] = args;
+    return toUnixEpochGroupExpression(column, interval, context);
+  });
+  result = replaceMacroFunction(result, '$__timeFilter', ([column]) => {
+    const timeColumn = normalizeColumn(column);
+    return `${timeColumn} >= ${fromMs} AND ${timeColumn} <= ${toMs}`;
+  });
+  result = replaceMacroFunction(result, '$__unixEpochFilter', ([column]) => {
+    const timeColumn = normalizeColumn(column);
+    return `${timeColumn} >= ${Math.floor(fromMs / MS_PER_SECOND)} AND ${timeColumn} <= ${Math.floor(
+      toMs / MS_PER_SECOND,
+    )}`;
+  });
+  result = replaceMacroFunction(result, '$__unixEpochNanoFilter', ([column]) => {
+    const timeColumn = normalizeColumn(column);
+    return `${timeColumn} >= ${fromMs * NS_PER_MS} AND ${timeColumn} <= ${toMs * NS_PER_MS}`;
+  });
+  result = replaceMacroFunction(result, '$__timeEpoch', ([column]) => {
+    return `to_unixtime(${toTimestampExpression(column)}) as time`;
+  });
+  result = replaceMacroFunction(result, '$__time', ([column]) => {
+    return `${toTimestampExpression(column)} as time`;
+  });
+  result = replaceZeroArgMacro(result, '$__timeFrom', String(fromMs));
+  result = replaceZeroArgMacro(result, '$__timeTo', String(toMs));
+  result = replaceZeroArgMacro(result, '$__unixEpochNanoFrom', String(fromMs * NS_PER_MS));
+  result = replaceZeroArgMacro(result, '$__unixEpochNanoTo', String(toMs * NS_PER_MS));
+
+  return replaceIntervalTokens(result, context);
+}
+
+/** @deprecated Use replaceClsSqlMacros. */
 export function replaceClsIntervalMacro(
   queryString: string,
   fromMs: number,
   toMs: number,
   maxDataPoints?: number,
 ): string {
-  if (!queryString.includes('$__cls_interval')) {
-    return queryString;
-  }
-  const rawSeconds = Math.max(1, Math.ceil((toMs - fromMs) / (maxDataPoints ?? 150) / 1000));
+  return replaceClsSqlMacros(queryString, fromMs, toMs, maxDataPoints);
+}
+
+function getRawIntervalSeconds({ fromMs, toMs, maxDataPoints = DEFAULT_MAX_DATA_POINTS }: MacroContext): number {
+  return Math.max(1, Math.ceil((toMs - fromMs) / maxDataPoints / MS_PER_SECOND));
+}
+
+function replaceIntervalTokens(queryString: string, context: MacroContext): string {
+  const rawSeconds = getRawIntervalSeconds(context);
+  const intervalMs = String(rawSeconds * MS_PER_SECOND);
+  const interval = `${rawSeconds} second`;
+
   return queryString
-    .replace(/\$__cls_interval_ms/g, String(rawSeconds * 1000))
-    .replace(/\$__cls_interval/g, `${rawSeconds} second`);
+    .replace(/\$__cls_interval_ms/g, intervalMs)
+    .replace(/\$__interval_ms/g, intervalMs)
+    .replace(/\$__cls_interval/g, interval)
+    .replace(/\$__interval/g, interval);
+}
+
+function replaceZeroArgMacro(queryString: string, macroName: string, replacement: string): string {
+  const withParentheses = replaceMacroFunction(queryString, macroName, () => replacement);
+  return replaceBareMacro(withParentheses, macroName, replacement);
+}
+
+function replaceBareMacro(queryString: string, macroName: string, replacement: string): string {
+  return queryString.replace(new RegExp(`${escapeRegExp(macroName)}(?![A-Za-z0-9_])`, 'g'), replacement);
+}
+
+function replaceMacroFunction(
+  queryString: string,
+  macroName: string,
+  replacementFactory: (args: string[], rawArgs: string) => string,
+): string {
+  let result = '';
+  let searchIndex = 0;
+
+  while (searchIndex < queryString.length) {
+    const macroIndex = queryString.indexOf(macroName, searchIndex);
+    if (macroIndex < 0) {
+      result += queryString.slice(searchIndex);
+      break;
+    }
+
+    let openParenIndex = macroIndex + macroName.length;
+    while (/\s/.test(queryString[openParenIndex] ?? '')) {
+      openParenIndex += 1;
+    }
+
+    if (queryString[openParenIndex] !== '(') {
+      result += queryString.slice(searchIndex, macroIndex + macroName.length);
+      searchIndex = macroIndex + macroName.length;
+      continue;
+    }
+
+    const closeParenIndex = findClosingParen(queryString, openParenIndex);
+    if (closeParenIndex < 0) {
+      result += queryString.slice(searchIndex, macroIndex + macroName.length);
+      searchIndex = macroIndex + macroName.length;
+      continue;
+    }
+
+    const rawArgs = queryString.slice(openParenIndex + 1, closeParenIndex);
+    result += queryString.slice(searchIndex, macroIndex);
+    result += replacementFactory(splitMacroArgs(rawArgs), rawArgs);
+    searchIndex = closeParenIndex + 1;
+  }
+
+  return result;
+}
+
+function findClosingParen(input: string, openParenIndex: number): number {
+  let depth = 0;
+  let quote: string | undefined;
+
+  for (let index = openParenIndex; index < input.length; index += 1) {
+    const char = input[index];
+    const previousChar = input[index - 1];
+
+    if (quote) {
+      if (char === quote && previousChar !== '\\') {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function splitMacroArgs(rawArgs: string): string[] {
+  const args: string[] = [];
+  let argStart = 0;
+  let depth = 0;
+  let quote: string | undefined;
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const char = rawArgs[index];
+    const previousChar = rawArgs[index - 1];
+
+    if (quote) {
+      if (char === quote && previousChar !== '\\') {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      depth -= 1;
+      continue;
+    }
+
+    if (char === ',' && depth === 0) {
+      args.push(rawArgs.slice(argStart, index).trim());
+      argStart = index + 1;
+    }
+  }
+
+  args.push(rawArgs.slice(argStart).trim());
+  return args.filter((arg) => arg.length > 0);
+}
+
+function toTimeGroupExpression(
+  column: string | undefined,
+  interval: string | undefined,
+  context: MacroContext,
+): string {
+  return `histogram(${toTimestampExpression(column)}, interval ${normalizeInterval(interval, context)})`;
+}
+
+function toUnixEpochGroupExpression(
+  column: string | undefined,
+  interval: string | undefined,
+  context: MacroContext,
+): string {
+  return `histogram(from_unixtime(${normalizeColumn(column)}), interval ${normalizeInterval(interval, context)})`;
+}
+
+function toTimestampExpression(column: string | undefined): string {
+  const normalizedColumn = normalizeColumn(column);
+  if (/^(cast|date_parse|from_iso8601_timestamp|from_unixtime)\s*\(/i.test(normalizedColumn)) {
+    return normalizedColumn;
+  }
+  return `cast(${normalizedColumn} as timestamp)`;
+}
+
+function normalizeInterval(interval: string | undefined, context: MacroContext): string {
+  return replaceIntervalTokens(interval?.trim() || '$__interval', context);
+}
+
+function normalizeColumn(column: string | undefined): string {
+  return column?.trim() || '__TIMESTAMP__';
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/src/log-service/common/utils/query.ts
+++ b/src/log-service/common/utils/query.ts
@@ -3,6 +3,51 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { QueryInfo } from '../../../types';
 
 /**
+ * Compute the CLS SQL histogram interval string for the given time range.
+ *
+ * Uses raw seconds (ceil) matching Grafana's $__interval behavior — no
+ * rounding to "nice" steps. This ensures $__cls_interval_ms is the exact
+ * divisor for TPM/RPM rate normalization, giving consistent values across
+ * different time range selections.
+ *
+ * Minimum bucket is 1 second.
+ *
+ * @example
+ * calcClsInterval(0, 3_600_000)     // "24 second"  (1 h / 150)
+ * calcClsInterval(0, 21_600_000)    // "144 second" (6 h / 150)
+ * calcClsInterval(0, 86_400_000)    // "576 second" (24 h / 150)
+ */
+export function calcClsInterval(fromMs: number, toMs: number, maxDataPoints = 150): string {
+  const rawSeconds = Math.max(1, Math.ceil((toMs - fromMs) / maxDataPoints / 1000));
+  return `${rawSeconds} second`;
+}
+
+/**
+ * Replace all occurrences of `$__cls_interval` in the query string with the
+ * computed CLS SQL interval expression (e.g. "24 second"), and
+ * `$__cls_interval_ms` with the exact corresponding millisecond value.
+ *
+ * Use `$__cls_interval_ms` in SELECT expressions to normalize counts/sums to
+ * per-minute rates — the divisor exactly matches the histogram bucket width:
+ *   count(*) / ($__cls_interval_ms / 60000.0) as rpm
+ *   sum(cast(input_tokens as double)) / ($__cls_interval_ms / 60000.0) as tpm
+ */
+export function replaceClsIntervalMacro(
+  queryString: string,
+  fromMs: number,
+  toMs: number,
+  maxDataPoints?: number,
+): string {
+  if (!queryString.includes('$__cls_interval')) {
+    return queryString;
+  }
+  const rawSeconds = Math.max(1, Math.ceil((toMs - fromMs) / (maxDataPoints ?? 150) / 1000));
+  return queryString
+    .replace(/\$__cls_interval_ms/g, String(rawSeconds * 1000))
+    .replace(/\$__cls_interval/g, `${rawSeconds} second`);
+}
+
+/**
  * 检索语法切割正则
  */
 export const CQL_SPLIT_PATTERN = /(\s*\|\s*)(select\b.*)/i;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface QueryInfo extends DataQuery {
   /** 数据源Query针对的查询服务，监控 or 日志 */
   serviceType?: ServiceType;
   logServiceParams?: {
-    region: string;
+    region?: string;
     TopicId: string;
     Query: string;
     SyntaxRule?: number;
@@ -97,6 +97,8 @@ export interface MyDataSourceOptions extends DataSourceJsonData {
   intranet?: boolean;
   language?: Language;
   enableExploreVisualizationTypes?: boolean;
+  /** default region, used as fallback when query does not specify region */
+  region?: string;
 }
 
 /**

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    ".config/types",
+    ".eslintrc.js",
+    ".prettierrc.js",
+    "jest.config.js",
+    "jest-setup.js",
+    "toolkit/**/*.js",
+    "webpack.config.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "alwaysStrict": false
   },
-  "include": ["../src", "./types", "./.eslintrc.js", "./webpack.config.ts"]
+  "include": ["src", ".config/types"]
 }


### PR DESCRIPTION
## Summary
- add topic-name/default-region support and keep CLS query refId/frame alignment
- add frontend topic-name resolution plus CLS/Grafana interval macros
- add CI build workflow and development prerelease packaging
- support Grafana SQL macro names for CLS SQL queries, adapted to CLS histogram/timestamp syntax
- fix local typecheck/lint configuration for this repository

## Grafana SQL macro support
- mirrors Grafana SQL macro names from `packages/grafana-sql/src/constants.ts`
- expands `$__timeGroup*` to CLS `histogram(cast(... as timestamp), interval ...)` expressions
- expands `$__timeFilter`, `$__time*`, `$__unixEpoch*`, and nano epoch range macros
- treats `$__interval` / `$__interval_ms` as aliases for existing CLS interval macros
- keeps existing `$__cls_interval` / `$__cls_interval_ms` behavior for compatibility

## Tests
- `pnpm typecheck`
- `pnpm test:ci`
- `pnpm exec jest --passWithNoTests --maxWorkers 4 --coverage=false --watch=false`
- `go test ./...`
- `go run github.com/magefile/mage test`
- `pnpm run lint`
- `pnpm run build`
- `go run github.com/magefile/mage build:backend`
- `git diff --check`
