### PR TITLE
Fix nullable CLS analysis record panic

### DIFF
--- a/pkg/cls/dataUtils.go
+++ b/pkg/cls/dataUtils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -97,43 +98,46 @@ func TransferAnalysisRecordsToFrame(list []map[string]interface{}, Columns []cls
 	}
 
 	for _, col := range Columns {
-		newFieldName := *col.Name
+		if col.Name == nil {
+			log.DefaultLogger.Warn("skip analysis column with empty name")
+			continue
+		}
+		colName := *col.Name
+		newFieldName := colName
 		if len(fieldName) > 0 {
 			newFieldName = fieldName
 		}
-		colType := GetFieldTypeByPrestoType(*col.Type)
+
+		colType := data.FieldTypeUnknown
+		if col.Type != nil {
+			colType = GetFieldTypeByPrestoType(*col.Type)
+		}
 
 		switch colType {
-		case data.FieldTypeInt64:
+		case data.FieldTypeInt64, data.FieldTypeFloat64:
 			{
-				//  由于是将用 map进行 JSON 解析，故这里用 float64
-				var m []float64
-				for _, v := range list {
-					m = append(m, v[*col.Name].(float64))
-				}
-				frame.Fields = append(frame.Fields, data.NewField(newFieldName, nil, m))
-			}
-		case data.FieldTypeFloat64:
-			{
-				var m []float64
-				for _, v := range list {
-					m = append(m, v[*col.Name].(float64))
+				// 由于是用 map 进行 JSON 解析，数值统一按 float64 透传给 Grafana。
+				m := make([]*float64, 0, len(list))
+				for _, record := range list {
+					m = append(m, toNullableFloat64(record[colName]))
 				}
 				frame.Fields = append(frame.Fields, data.NewField(newFieldName, nil, m))
 			}
 
 		case data.FieldTypeTime:
 			{
-				var m []time.Time
-				for _, v := range list {
-					t, err := parseTimeString(v[*col.Name].(string), loc)
-					if err != nil {
-						// 简单的警告日志，避免依赖问题
-						log.DefaultLogger.Warn("time parsing failed, using current time", "timeString", v[*col.Name].(string), "error", err)
-						m = append(m, time.Now())
-					} else {
-						m = append(m, t)
-					}
+				m := make([]*time.Time, 0, len(list))
+				for _, record := range list {
+					m = append(m, toNullableTime(record[colName], loc, colName))
+				}
+				frame.Fields = append(frame.Fields, data.NewField(newFieldName, nil, m))
+			}
+
+		case data.FieldTypeBool:
+			{
+				m := make([]*bool, 0, len(list))
+				for _, record := range list {
+					m = append(m, toNullableBool(record[colName]))
 				}
 				frame.Fields = append(frame.Fields, data.NewField(newFieldName, nil, m))
 			}
@@ -143,15 +147,158 @@ func TransferAnalysisRecordsToFrame(list []map[string]interface{}, Columns []cls
 			fallthrough
 		case data.FieldTypeString:
 			{
-				var m []string
-				for _, v := range list {
-					m = append(m, v[*col.Name].(string))
+				m := make([]*string, 0, len(list))
+				for _, record := range list {
+					m = append(m, toNullableString(record[colName]))
 				}
 				frame.Fields = append(frame.Fields, data.NewField(newFieldName, nil, m))
 			}
 		}
 	}
 	return []*data.Frame{frame}
+}
+
+func toNullableFloat64(value interface{}) *float64 {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case float64:
+		return &v
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return nil
+		}
+		return &f
+	case string:
+		return parseNullableFloat64(v)
+	case []byte:
+		return parseNullableFloat64(string(v))
+	default:
+		return parseNullableFloat64(fmt.Sprint(v))
+	}
+}
+
+func parseNullableFloat64(value string) *float64 {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return nil
+	}
+	return &f
+}
+
+func toNullableTime(value interface{}, loc *time.Location, colName string) *time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		return &v
+	case *time.Time:
+		return v
+	case float64:
+		return unixNumberToTime(v)
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return nil
+		}
+		return unixNumberToTime(f)
+	case string:
+		return parseNullableTimeString(v, loc, colName)
+	case []byte:
+		return parseNullableTimeString(string(v), loc, colName)
+	default:
+		return parseNullableTimeString(fmt.Sprint(v), loc, colName)
+	}
+}
+
+func unixNumberToTime(value float64) *time.Time {
+	if value > 1e12 && value < 2e12 {
+		millisec := int64(value)
+		t := time.Unix(millisec/1000, (millisec%1000)*1e6)
+		return &t
+	}
+	if value > 1e9 && value < 2e9 {
+		sec := int64(value)
+		nsec := int64((value - float64(sec)) * 1e9)
+		t := time.Unix(sec, nsec)
+		return &t
+	}
+	return nil
+}
+
+func parseNullableTimeString(value string, loc *time.Location, colName string) *time.Time {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	t, err := parseTimeString(trimmed, loc)
+	if err != nil {
+		log.DefaultLogger.Warn("time parsing failed, using null", "column", colName, "timeString", trimmed, "error", err)
+		return nil
+	}
+	return &t
+}
+
+func toNullableBool(value interface{}) *bool {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case bool:
+		return &v
+	case float64:
+		b := v != 0
+		return &b
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return nil
+		}
+		b := f != 0
+		return &b
+	case string:
+		return parseNullableBool(v)
+	case []byte:
+		return parseNullableBool(string(v))
+	default:
+		return parseNullableBool(fmt.Sprint(v))
+	}
+}
+
+func parseNullableBool(value string) *bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	b, err := strconv.ParseBool(trimmed)
+	if err == nil {
+		return &b
+	}
+	f, err := strconv.ParseFloat(trimmed, 64)
+	if err == nil {
+		b = f != 0
+		return &b
+	}
+	return nil
+}
+
+func toNullableString(value interface{}) *string {
+	if value == nil {
+		return nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		s = fmt.Sprint(value)
+	}
+	return &s
 }
 
 func GetLog(logInfos []*clsAPI.LogInfo, refId string) []*data.Frame {

--- a/pkg/cls/dataUtils_test.go
+++ b/pkg/cls/dataUtils_test.go
@@ -1,0 +1,202 @@
+package cls
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	clsAPI "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
+)
+
+func TestTransferAnalysisRecordsToFrameHandlesNullableValues(t *testing.T) {
+	loc := time.UTC
+	columns := []clsAPI.Column{
+		{Name: stringPtr("message"), Type: stringPtr("varchar")},
+		{Name: stringPtr("count"), Type: stringPtr("bigint")},
+		{Name: stringPtr("ratio"), Type: stringPtr("double")},
+		{Name: stringPtr("created_at"), Type: stringPtr("timestamp")},
+		{Name: stringPtr("ok"), Type: stringPtr("boolean")},
+		{Name: stringPtr("payload"), Type: stringPtr("json")},
+		{Name: stringPtr("missing"), Type: stringPtr("varchar")},
+	}
+	list := []map[string]interface{}{
+		{
+			"message":    "hello",
+			"count":      float64(1),
+			"ratio":      "2.5",
+			"created_at": "2026-06-26 11:39:44",
+			"ok":         true,
+			"payload":    map[string]interface{}{"k": "v"},
+		},
+		{
+			"message":    nil,
+			"count":      nil,
+			"ratio":      "",
+			"created_at": nil,
+			"ok":         "false",
+			"payload":    nil,
+		},
+		{
+			"message":    float64(42),
+			"count":      "3.5",
+			"ratio":      []byte("4.25"),
+			"created_at": "not-a-time",
+			"ok":         1,
+			"payload":    []string{"a", "b"},
+		},
+	}
+
+	frames := TransferAnalysisRecordsToFrame(list, columns, "frame", "", loc)
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+	frame := frames[0]
+	if frame.Name != "frame" {
+		t.Fatalf("unexpected frame name: %q", frame.Name)
+	}
+	if got := len(frame.Fields); got != len(columns) {
+		t.Fatalf("expected %d fields, got %d", len(columns), got)
+	}
+
+	message := frame.Fields[0]
+	assertField(t, message, "message", data.FieldTypeNullableString, 3)
+	assertStringPtr(t, message.At(0), "hello")
+	assertNilAt(t, message, 1)
+	assertStringPtr(t, message.At(2), "42")
+
+	count := frame.Fields[1]
+	assertField(t, count, "count", data.FieldTypeNullableFloat64, 3)
+	assertFloatPtr(t, count.At(0), 1)
+	assertNilAt(t, count, 1)
+	assertFloatPtr(t, count.At(2), 3.5)
+
+	ratio := frame.Fields[2]
+	assertField(t, ratio, "ratio", data.FieldTypeNullableFloat64, 3)
+	assertFloatPtr(t, ratio.At(0), 2.5)
+	assertNilAt(t, ratio, 1)
+	assertFloatPtr(t, ratio.At(2), 4.25)
+
+	createdAt := frame.Fields[3]
+	assertField(t, createdAt, "created_at", data.FieldTypeNullableTime, 3)
+	expectedTime := time.Date(2026, 6, 26, 11, 39, 44, 0, time.UTC)
+	assertTimePtr(t, createdAt.At(0), expectedTime)
+	assertNilAt(t, createdAt, 1)
+	assertNilAt(t, createdAt, 2)
+
+	ok := frame.Fields[4]
+	assertField(t, ok, "ok", data.FieldTypeNullableBool, 3)
+	assertBoolPtr(t, ok.At(0), true)
+	assertBoolPtr(t, ok.At(1), false)
+	assertBoolPtr(t, ok.At(2), true)
+
+	payload := frame.Fields[5]
+	assertField(t, payload, "payload", data.FieldTypeNullableString, 3)
+	assertStringPtr(t, payload.At(0), "map[k:v]")
+	assertNilAt(t, payload, 1)
+	assertStringPtr(t, payload.At(2), "[a b]")
+
+	missing := frame.Fields[6]
+	assertField(t, missing, "missing", data.FieldTypeNullableString, 3)
+	assertNilAt(t, missing, 0)
+	assertNilAt(t, missing, 1)
+	assertNilAt(t, missing, 2)
+}
+
+func TestTransferAnalysisRecordsToFrameHandlesColumnMetadataEdges(t *testing.T) {
+	columns := []clsAPI.Column{
+		{Name: nil, Type: stringPtr("varchar")},
+		{Name: stringPtr("unknown_type"), Type: nil},
+	}
+	list := []map[string]interface{}{{"unknown_type": "value"}}
+
+	frames := TransferAnalysisRecordsToFrame(list, columns, "", "", time.UTC)
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+	frame := frames[0]
+	if got := len(frame.Fields); got != 1 {
+		t.Fatalf("expected nil-name column to be skipped, got %d fields", got)
+	}
+	assertField(t, frame.Fields[0], "unknown_type", data.FieldTypeNullableString, 1)
+	assertStringPtr(t, frame.Fields[0].At(0), "value")
+}
+
+func TestTransferAnalysisRecordsToFrameAppliesFieldNameOverride(t *testing.T) {
+	columns := []clsAPI.Column{{Name: stringPtr("message"), Type: stringPtr("varchar")}}
+	list := []map[string]interface{}{{"message": "hello"}}
+
+	frames := TransferAnalysisRecordsToFrame(list, columns, "", "alias", time.UTC)
+	if len(frames) != 1 || len(frames[0].Fields) != 1 {
+		t.Fatalf("unexpected frames: %#v", frames)
+	}
+	assertField(t, frames[0].Fields[0], "alias", data.FieldTypeNullableString, 1)
+	assertStringPtr(t, frames[0].Fields[0].At(0), "hello")
+}
+
+func stringPtr(v string) *string {
+	return &v
+}
+
+func assertField(t *testing.T, field *data.Field, name string, fieldType data.FieldType, length int) {
+	t.Helper()
+	if field.Name != name {
+		t.Fatalf("unexpected field name: got %q want %q", field.Name, name)
+	}
+	if field.Type() != fieldType {
+		t.Fatalf("unexpected field type for %s: got %v want %v", name, field.Type(), fieldType)
+	}
+	if field.Len() != length {
+		t.Fatalf("unexpected field length for %s: got %d want %d", name, field.Len(), length)
+	}
+}
+
+func assertNilAt(t *testing.T, field *data.Field, idx int) {
+	t.Helper()
+	if !field.NilAt(idx) {
+		t.Fatalf("expected %s[%d] to be nil, got %#v", field.Name, idx, field.At(idx))
+	}
+}
+
+func assertStringPtr(t *testing.T, got interface{}, want string) {
+	t.Helper()
+	value, ok := got.(*string)
+	if !ok || value == nil {
+		t.Fatalf("expected *string %q, got %#v", want, got)
+	}
+	if *value != want {
+		t.Fatalf("unexpected string: got %q want %q", *value, want)
+	}
+}
+
+func assertFloatPtr(t *testing.T, got interface{}, want float64) {
+	t.Helper()
+	value, ok := got.(*float64)
+	if !ok || value == nil {
+		t.Fatalf("expected *float64 %v, got %#v", want, got)
+	}
+	if *value != want {
+		t.Fatalf("unexpected float: got %v want %v", *value, want)
+	}
+}
+
+func assertTimePtr(t *testing.T, got interface{}, want time.Time) {
+	t.Helper()
+	value, ok := got.(*time.Time)
+	if !ok || value == nil {
+		t.Fatalf("expected *time.Time %v, got %#v", want, got)
+	}
+	if !value.Equal(want) {
+		t.Fatalf("unexpected time: got %v want %v", *value, want)
+	}
+}
+
+func assertBoolPtr(t *testing.T, got interface{}, want bool) {
+	t.Helper()
+	value, ok := got.(*bool)
+	if !ok || value == nil {
+		t.Fatalf("expected *bool %v, got %#v", want, got)
+	}
+	if *value != want {
+		t.Fatalf("unexpected bool: got %v want %v", *value, want)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent backend panic when CLS analysis records contain `null`, missing fields, or values whose JSON type does not match the Presto column type exactly
- preserve nulls with Grafana nullable fields instead of coercing them to empty strings, zero values, or current time
- handle boolean analysis columns explicitly and guard nil column metadata
- add focused tests for nullable/missing strings, numbers, timestamps, booleans, unknown types, and field-name overrides

## Root cause
`TransferAnalysisRecordsToFrame` converted JSON-decoded analysis rows with direct assertions like `.(string)` and `.(float64)`. CLS SQL analysis results can return `null` or omit a field, which panics the plugin process and surfaces in Grafana as `plugin.connectionUnavailable` / EOF.

## Tests
- `go test ./pkg/cls -run 'TestTransferAnalysisRecordsToFrame' -count=1 -v`
- `go test ./...`
- `go run github.com/magefile/mage test`
- `go run github.com/magefile/mage build:backend`
- `git diff --check`
