### PR TITLE
Support Grafana SQL macros for CLS queries

### DIFF
--- a/src/log-service/LogServiceDataSource.ts
+++ b/src/log-service/LogServiceDataSource.ts
@@ -25,7 +25,7 @@ import {
 import { DescribeLogContext, LogInfo, SearchLog } from '../common/model';
 import { MyDataSourceOptions, QueryInfo } from '../types';
 import { toTimeSeriesMany } from './common/format/prepareTimeSeries';
-import { addQueryResultLimit, getRawQuery, replaceClsQueryWithTemplateSrv } from './common/utils/query';
+import { addQueryResultLimit, getRawQuery, replaceClsQueryWithTemplateSrv, replaceClsSqlMacros } from './common/utils/query';
 
 export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceOptions> {
   public readonly instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>;
@@ -37,13 +37,18 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
   }
 
   query(request: DataQueryRequest<QueryInfo>) {
-    const { range, targets, scopedVars } = request;
+    const { range, targets, scopedVars, maxDataPoints } = request;
     const [from, to] = [range.from, range.to].map((item) => item.valueOf()) as number[];
     const requestTargets = targets.map((target) => {
       const region = target.logServiceParams?.region ? getTemplateSrv().replace(target.logServiceParams.region) : '';
       const TopicId = target.logServiceParams?.TopicId ? getTemplateSrv().replace(target.logServiceParams.TopicId) : '';
       const Query = addQueryResultLimit(
-        replaceClsQueryWithTemplateSrv(target.logServiceParams?.Query || '', scopedVars),
+        replaceClsSqlMacros(
+          replaceClsQueryWithTemplateSrv(target.logServiceParams?.Query || '', scopedVars),
+          from,
+          to,
+          maxDataPoints,
+        ),
         target.logServiceParams,
       );
 
@@ -148,7 +153,11 @@ export class LogServiceDataSource extends DataSourceApi<QueryInfo, MyDataSourceO
     const region = logServiceParams?.region ? getTemplateSrv().replace(logServiceParams.region) : '';
     const TopicId = logServiceParams?.TopicId ? getTemplateSrv().replace(logServiceParams.TopicId) : '';
     const Query = addQueryResultLimit(
-      replaceClsQueryWithTemplateSrv(logServiceParams?.Query as string),
+      replaceClsSqlMacros(
+        replaceClsQueryWithTemplateSrv(logServiceParams?.Query as string),
+        options.range!.from.valueOf(),
+        options.range!.to.valueOf(),
+      ),
       logServiceParams,
     );
 

--- a/src/log-service/common/utils/query.test.ts
+++ b/src/log-service/common/utils/query.test.ts
@@ -1,0 +1,123 @@
+import { CLS_SQL_MACRO_NAMES, replaceClsSqlMacros } from './query';
+
+const h = (n: number) => n * 3_600_000;
+
+const fromMs = 1_700_000_000_000;
+const toMs = fromMs + h(6);
+
+describe('CLS SQL macro metadata', () => {
+  it('mirrors Grafana SQL macro names and interval aliases', () => {
+    expect(CLS_SQL_MACRO_NAMES).toEqual([
+      '$__time',
+      '$__timeEpoch',
+      '$__timeFilter',
+      '$__timeFrom',
+      '$__timeTo',
+      '$__timeGroup',
+      '$__timeGroupAlias',
+      '$__unixEpochFilter',
+      '$__unixEpochNanoFilter',
+      '$__unixEpochNanoFrom',
+      '$__unixEpochNanoTo',
+      '$__unixEpochGroup',
+      '$__unixEpochGroupAlias',
+      '$__interval',
+      '$__interval_ms',
+    ]);
+  });
+});
+
+describe('replaceClsSqlMacros interval aliases', () => {
+  it('replaces $__interval and $__interval_ms', () => {
+    const query = 'histogram(ts, interval $__interval), count(*) / ($__interval_ms / 60000.0) as rpm';
+    expect(replaceClsSqlMacros(query, 0, h(6))).toBe(
+      'histogram(ts, interval 144 second), count(*) / (144000 / 60000.0) as rpm'
+    );
+  });
+
+  it('does not replace legacy CLS interval aliases', () => {
+    const query = '$__cls_interval $__cls_interval_ms $__interval $__interval_ms';
+    expect(replaceClsSqlMacros(query, 0, h(1))).toBe('$__cls_interval $__cls_interval_ms 24 second 24000');
+  });
+
+  it('returns query unchanged when no macro exists', () => {
+    const query = '* | select count(*)';
+    expect(replaceClsSqlMacros(query, 0, h(1))).toBe(query);
+  });
+});
+
+describe('replaceClsSqlMacros time macros', () => {
+  it('expands $__timeGroup to CLS histogram syntax', () => {
+    const query = '* | select $__timeGroup(__TIMESTAMP__, $__interval), count(*) as cnt group by 1';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 144 second), count(*) as cnt group by 1'
+    );
+  });
+
+  it('expands $__timeGroupAlias with time alias', () => {
+    const query = '* | select $__timeGroupAlias(__TIMESTAMP__, $__interval), count(*) group by time';
+    expect(replaceClsSqlMacros(query, fromMs, toMs, 1000)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 22 second) as time, count(*) group by time'
+    );
+  });
+
+  it('converts Grafana shorthand intervals to CLS interval syntax', () => {
+    const query = '* | select $__timeGroupAlias(__TIMESTAMP__, \'5m\'), $__timeGroup(ts, "1h")';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 5 minute) as time, histogram(cast(ts as timestamp), interval 1 hour)'
+    );
+  });
+
+  it('uses $__interval when time group interval is omitted', () => {
+    const query = '* | select $__timeGroupAlias(__TIMESTAMP__), count(*) group by time';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      '* | select histogram(cast(__TIMESTAMP__ as timestamp), interval 144 second) as time, count(*) group by time'
+    );
+  });
+
+  it('expands $__time and $__timeEpoch', () => {
+    expect(replaceClsSqlMacros('$__time(__TIMESTAMP__)', fromMs, toMs)).toBe(
+      'cast(__TIMESTAMP__ as timestamp) as time'
+    );
+    expect(replaceClsSqlMacros('$__time(cast(ts as timestamp))', fromMs, toMs)).toBe('cast(ts as timestamp) as time');
+    expect(replaceClsSqlMacros('$__timeEpoch(__TIMESTAMP__)', fromMs, toMs)).toBe(
+      'to_unixtime(cast(__TIMESTAMP__ as timestamp)) as time'
+    );
+  });
+
+  it('expands $__timeFilter and zero-arg time bounds', () => {
+    const query = '* | select count(*) where $__timeFilter(__TIMESTAMP__) and ts >= $__timeFrom() and ts <= $__timeTo';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      '* | select count(*) where cast(__TIMESTAMP__ as timestamp) >= from_unixtime(1700000000) AND cast(__TIMESTAMP__ as timestamp) <= from_unixtime(1700021600) and ts >= from_unixtime(1700000000) and ts <= from_unixtime(1700021600)'
+    );
+  });
+
+  it('parses nested comma expressions inside macro arguments', () => {
+    const query = "* | select $__timeGroupAlias(date_parse(ts, '%Y-%m-%d,%H:%i:%s'), $__interval), count(*)";
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      "* | select histogram(date_parse(ts, '%Y-%m-%d,%H:%i:%s'), interval 144 second) as time, count(*)"
+    );
+  });
+});
+
+describe('replaceClsSqlMacros unix epoch macros', () => {
+  it('expands $__unixEpochFilter', () => {
+    expect(replaceClsSqlMacros('$__unixEpochFilter(epoch_s)', fromMs, toMs)).toBe(
+      'epoch_s >= 1700000000 AND epoch_s <= 1700021600'
+    );
+  });
+
+  it('expands $__unixEpochNanoFilter and nano bounds', () => {
+    const query = '$__unixEpochNanoFilter(epoch_ns) $__unixEpochNanoFrom() $__unixEpochNanoTo';
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      'epoch_ns >= 1700000000000000000 AND epoch_ns <= 1700021600000000000 1700000000000000000 1700021600000000000'
+    );
+  });
+
+  it('expands unix epoch group macros using from_unixtime', () => {
+    const query = "$__unixEpochGroupAlias(epoch_s, $__interval), $__unixEpochGroup(epoch_s, '5m')";
+    expect(replaceClsSqlMacros(query, fromMs, toMs)).toBe(
+      'histogram(from_unixtime(epoch_s), interval 144 second) as time, histogram(from_unixtime(epoch_s), interval 5 minute)'
+    );
+  });
+});

--- a/src/log-service/common/utils/query.ts
+++ b/src/log-service/common/utils/query.ts
@@ -2,6 +2,315 @@ import { getTemplateSrv } from '@grafana/runtime';
 
 import { QueryInfo } from '../../../types';
 
+const DEFAULT_MAX_DATA_POINTS = 150;
+const MS_PER_SECOND = 1000;
+
+export const CLS_SQL_MACRO_NAMES = [
+  '$__time',
+  '$__timeEpoch',
+  '$__timeFilter',
+  '$__timeFrom',
+  '$__timeTo',
+  '$__timeGroup',
+  '$__timeGroupAlias',
+  '$__unixEpochFilter',
+  '$__unixEpochNanoFilter',
+  '$__unixEpochNanoFrom',
+  '$__unixEpochNanoTo',
+  '$__unixEpochGroup',
+  '$__unixEpochGroupAlias',
+  '$__interval',
+  '$__interval_ms',
+];
+
+type MacroContext = {
+  fromMs: number;
+  toMs: number;
+  maxDataPoints?: number;
+};
+
+function getRawIntervalSeconds({ fromMs, toMs, maxDataPoints = DEFAULT_MAX_DATA_POINTS }: MacroContext): number {
+  return Math.max(1, Math.ceil((toMs - fromMs) / maxDataPoints / MS_PER_SECOND));
+}
+
+function getInterval(context: MacroContext): string {
+  return `${getRawIntervalSeconds(context)} second`;
+}
+
+function getIntervalMs(context: MacroContext): string {
+  return String(getRawIntervalSeconds(context) * MS_PER_SECOND);
+}
+
+function getEpochSeconds(ms: number): string {
+  return String(Math.floor(ms / MS_PER_SECOND));
+}
+
+function getUnixSeconds(ms: number): string {
+  const seconds = Math.trunc(ms) / MS_PER_SECOND;
+  if (Number.isInteger(seconds)) {
+    return String(seconds);
+  }
+  return seconds.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function getEpochNano(ms: number): string {
+  return `${Math.trunc(ms)}000000`;
+}
+
+function getTimeExpression(ms: number): string {
+  return `from_unixtime(${getUnixSeconds(ms)})`;
+}
+
+function replaceIntervalMacros(queryString: string, context: MacroContext): string {
+  return queryString.replace(/\$__interval_ms/g, getIntervalMs(context)).replace(/\$__interval/g, getInterval(context));
+}
+
+function normalizeColumn(column: string | undefined): string {
+  return column?.trim() || '__TIMESTAMP__';
+}
+
+function normalizeInterval(interval: string | undefined, context: MacroContext): string {
+  const value = replaceIntervalMacros(interval?.trim() || '$__interval', context).replace(/^['"]|['"]$/g, '');
+  const durationMatch = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d|w)$/i.exec(value);
+  if (!durationMatch) {
+    return value;
+  }
+
+  const amount = Number(durationMatch[1]);
+  switch (durationMatch[2].toLowerCase()) {
+    case 'ms':
+      return `${Math.max(1, Math.ceil(amount / MS_PER_SECOND))} second`;
+    case 's':
+      return `${amount} second`;
+    case 'm':
+      return `${amount} minute`;
+    case 'h':
+      return `${amount} hour`;
+    case 'd':
+      return `${amount} day`;
+    case 'w':
+      return `${amount * 7} day`;
+    default:
+      return value;
+  }
+}
+
+function toTimestampExpression(column: string | undefined): string {
+  const normalizedColumn = normalizeColumn(column);
+  if (/^(cast|date_parse|from_iso8601_timestamp|from_unixtime)\s*\(/i.test(normalizedColumn)) {
+    return normalizedColumn;
+  }
+  return `cast(${normalizedColumn} as timestamp)`;
+}
+
+function toTimeGroupExpression(
+  column: string | undefined,
+  interval: string | undefined,
+  context: MacroContext
+): string {
+  return `histogram(${toTimestampExpression(column)}, interval ${normalizeInterval(interval, context)})`;
+}
+
+function toUnixEpochGroupExpression(
+  column: string | undefined,
+  interval: string | undefined,
+  context: MacroContext
+): string {
+  return `histogram(from_unixtime(${normalizeColumn(column)}), interval ${normalizeInterval(interval, context)})`;
+}
+
+function replaceZeroArgMacro(queryString: string, macroName: string, replacement: string): string {
+  return replaceBareMacro(
+    replaceMacroFunction(queryString, macroName, () => replacement),
+    macroName,
+    replacement
+  );
+}
+
+function replaceBareMacro(queryString: string, macroName: string, replacement: string): string {
+  return queryString.replace(new RegExp(`${escapeRegExp(macroName)}(?![A-Za-z0-9_])`, 'g'), replacement);
+}
+
+function replaceMacroFunction(
+  queryString: string,
+  macroName: string,
+  replacementFactory: (args: string[], rawArgs: string) => string
+): string {
+  let result = '';
+  let searchIndex = 0;
+
+  while (searchIndex < queryString.length) {
+    const macroIndex = queryString.indexOf(macroName, searchIndex);
+    if (macroIndex < 0) {
+      result += queryString.slice(searchIndex);
+      break;
+    }
+
+    let openParenIndex = macroIndex + macroName.length;
+    while (/\s/.test(queryString[openParenIndex] ?? '')) {
+      openParenIndex += 1;
+    }
+
+    if (queryString[openParenIndex] !== '(') {
+      result += queryString.slice(searchIndex, macroIndex + macroName.length);
+      searchIndex = macroIndex + macroName.length;
+      continue;
+    }
+
+    const closeParenIndex = findClosingParen(queryString, openParenIndex);
+    if (closeParenIndex < 0) {
+      result += queryString.slice(searchIndex, macroIndex + macroName.length);
+      searchIndex = macroIndex + macroName.length;
+      continue;
+    }
+
+    const rawArgs = queryString.slice(openParenIndex + 1, closeParenIndex);
+    result += queryString.slice(searchIndex, macroIndex);
+    result += replacementFactory(splitMacroArgs(rawArgs), rawArgs);
+    searchIndex = closeParenIndex + 1;
+  }
+
+  return result;
+}
+
+function findClosingParen(input: string, openParenIndex: number): number {
+  let depth = 0;
+  let quote: string | undefined;
+
+  for (let index = openParenIndex; index < input.length; index += 1) {
+    const char = input[index];
+    const previousChar = input[index - 1];
+
+    if (quote) {
+      if (char === quote && previousChar !== '\\') {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function splitMacroArgs(rawArgs: string): string[] {
+  const args: string[] = [];
+  let argStart = 0;
+  let depth = 0;
+  let quote: string | undefined;
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const char = rawArgs[index];
+    const previousChar = rawArgs[index - 1];
+
+    if (quote) {
+      if (char === quote && previousChar !== '\\') {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      depth -= 1;
+      continue;
+    }
+
+    if (char === ',' && depth === 0) {
+      args.push(rawArgs.slice(argStart, index).trim());
+      argStart = index + 1;
+    }
+  }
+
+  args.push(rawArgs.slice(argStart).trim());
+  return args.filter((arg) => arg.length > 0);
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace Grafana SQL-style macros in CLS query strings.
+ *
+ * The macro names mirror Grafana SQL's common macro list, while the generated
+ * expressions are adapted to CLS SQL syntax.
+ */
+export function replaceClsSqlMacros(queryString: string, fromMs: number, toMs: number, maxDataPoints?: number): string {
+  if (!queryString.includes('$__')) {
+    return queryString;
+  }
+
+  const context: MacroContext = { fromMs, toMs, maxDataPoints };
+  let result = queryString;
+
+  result = replaceMacroFunction(result, '$__timeGroupAlias', (args) => {
+    const [column, interval] = args;
+    return `${toTimeGroupExpression(column, interval, context)} as time`;
+  });
+  result = replaceMacroFunction(result, '$__timeGroup', (args) => {
+    const [column, interval] = args;
+    return toTimeGroupExpression(column, interval, context);
+  });
+  result = replaceMacroFunction(result, '$__unixEpochGroupAlias', (args) => {
+    const [column, interval] = args;
+    return `${toUnixEpochGroupExpression(column, interval, context)} as time`;
+  });
+  result = replaceMacroFunction(result, '$__unixEpochGroup', (args) => {
+    const [column, interval] = args;
+    return toUnixEpochGroupExpression(column, interval, context);
+  });
+  result = replaceMacroFunction(result, '$__timeFilter', ([column]) => {
+    const timeColumn = toTimestampExpression(column);
+    return `${timeColumn} >= ${getTimeExpression(fromMs)} AND ${timeColumn} <= ${getTimeExpression(toMs)}`;
+  });
+  result = replaceMacroFunction(result, '$__unixEpochFilter', ([column]) => {
+    const timeColumn = normalizeColumn(column);
+    return `${timeColumn} >= ${getEpochSeconds(fromMs)} AND ${timeColumn} <= ${getEpochSeconds(toMs)}`;
+  });
+  result = replaceMacroFunction(result, '$__unixEpochNanoFilter', ([column]) => {
+    const timeColumn = normalizeColumn(column);
+    return `${timeColumn} >= ${getEpochNano(fromMs)} AND ${timeColumn} <= ${getEpochNano(toMs)}`;
+  });
+  result = replaceMacroFunction(result, '$__timeEpoch', ([column]) => {
+    return `to_unixtime(${toTimestampExpression(column)}) as time`;
+  });
+  result = replaceMacroFunction(result, '$__time', ([column]) => {
+    return `${toTimestampExpression(column)} as time`;
+  });
+  result = replaceZeroArgMacro(result, '$__timeFrom', getTimeExpression(fromMs));
+  result = replaceZeroArgMacro(result, '$__timeTo', getTimeExpression(toMs));
+  result = replaceZeroArgMacro(result, '$__unixEpochNanoFrom', getEpochNano(fromMs));
+  result = replaceZeroArgMacro(result, '$__unixEpochNanoTo', getEpochNano(toMs));
+
+  return replaceIntervalMacros(result, context);
+}
+
 /**
  * 检索语法切割正则
  */


### PR DESCRIPTION
## Summary
- add Grafana SQL-style macro expansion for CLS SQL queries
- expand `$__timeGroup*` to CLS `histogram(cast(... as timestamp), interval ...)` syntax
- expand `$__timeFilter`, `$__time*`, `$__unixEpoch*`, and nano epoch range macros
- treat `$__interval` and `$__interval_ms` as Grafana-compatible interval aliases

## Scope
This PR is intentionally macro-only. It does not include topic-name/default-region changes, CI/lint config changes, backend panic fixes, or legacy `$__cls_interval*` compatibility aliases.

## Tests
- `pnpm exec jest src/log-service/common/utils/query.test.ts --runInBand --coverage=false --watch=false`
- `pnpm test:ci`
- `pnpm run build`
- `go test ./...`
- `git diff --check`
- `pnpm exec prettier --config .prettierrc.js --check src/log-service/common/utils/query.ts src/log-service/common/utils/query.test.ts src/log-service/LogServiceDataSource.ts`
- focused `tsc` on changed TS files with explicit compiler options

## Notes
- `pnpm typecheck` currently fails on upstream config because `webpack.config.ts` is included while `.config/tsconfig.json` sets `rootDir` to `src`.
- Full `pnpm run lint` currently fails on existing upstream config/parser issues unrelated to this PR; no lint config changes are included here to keep this PR focused.
